### PR TITLE
Add 'future' library for Python 2/3 support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,3 +15,11 @@
     version: "{{ omero_omego_version }}"
     virtualenv: "{{ omero_common_basedir }}/omego"
     virtualenv_site_packages: true
+
+- name: omego | install future
+  become: true
+  pip:
+    name: future
+    state: present
+    virtualenv: "{{ omero_common_basedir }}/omego"
+    virtualenv_site_packages: true


### PR DESCRIPTION
While both versions are being supported, future will
be needed _before_ omero-server role in order to get
download the server zip.