### PR TITLE
Bump default omego version to 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Role Variables
 
 Optional, see [defaults/main.yml](defaults/main.yml) for values:
 
-- `omero_omego_version`: The `omego` version to install.
+- `omero_omego_version`: The `omego` version to install (default: 0.7.0).
 
 
 Author Information

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 
-omero_omego_version: 0.6.5
+omero_omego_version: 0.7.0


### PR DESCRIPTION
This role version should include Python 2/3 support as well as fixing for deploying OMERO in a Python 3 environment

All features should be backwards compatible. Proposed tag: 0.1.4 or 0.2.0. 